### PR TITLE
Wire visualize dashboard to uploaded CSV data

### DIFF
--- a/src/pages/api/visualize.ts
+++ b/src/pages/api/visualize.ts
@@ -1,0 +1,129 @@
+import fs from "fs";
+import path from "path";
+import formidable, { File as FormidableFile } from "formidable";
+import { NextApiRequest, NextApiResponse } from "next";
+import { spawn } from "child_process";
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+type ParseResult = {
+  fields: formidable.Fields;
+  files: formidable.Files;
+};
+
+type VisualizeResponse = {
+  missionMix?: unknown;
+  missingness?: unknown;
+  error?: string;
+};
+
+function parseUpload(req: NextApiRequest, uploadDir: string): Promise<ParseResult> {
+  return new Promise((resolve, reject) => {
+    const form = formidable({ uploadDir, keepExtensions: true });
+    form.parse(req, (err, fields, files) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve({ fields, files });
+      }
+    });
+  });
+}
+
+function findFile(files: formidable.Files): FormidableFile | null {
+  const entry = files.file;
+  if (!entry) return null;
+  if (Array.isArray(entry)) {
+    return entry[0] ?? null;
+  }
+  return entry as FormidableFile;
+}
+
+async function runPythonVisualize(bundleDir: string, csvPath: string): Promise<VisualizeResponse> {
+  const scriptPath = path.join(process.cwd(), "exo_infer.py");
+  if (!fs.existsSync(scriptPath)) {
+    return { error: "Inference script not found" };
+  }
+  if (!fs.existsSync(bundleDir)) {
+    return { error: "Model bundle directory not found" };
+  }
+
+  return new Promise((resolve, reject) => {
+    const py =
+      process.env.PYTHON_BIN ||
+      (process.platform === "win32" ? "python" : "python3");
+
+    const proc = spawn(py, [scriptPath, "--mode", "visualize", bundleDir, csvPath]);
+
+    let stdout = "";
+    let stderr = "";
+
+    proc.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    proc.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(stderr || `Visualize exited with code ${code}`));
+        return;
+      }
+      try {
+        const payload = JSON.parse(stdout.trim() || "{}");
+        resolve(payload);
+      } catch (err) {
+        reject(new Error(`Unable to parse visualize output: ${(err as Error).message}\n${stdout}`));
+      }
+    });
+  });
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  const uploadDir = path.join(process.cwd(), "public", "uploads");
+  await fs.promises.mkdir(uploadDir, { recursive: true });
+
+  try {
+    const { files } = await parseUpload(req, uploadDir);
+    const file = findFile(files);
+    if (!file) {
+      res.status(400).json({ error: "No file uploaded" });
+      return;
+    }
+
+    const csvPath = file.filepath
+      ? file.filepath
+      : file.newFilename
+      ? path.join(uploadDir, file.newFilename)
+      : null;
+
+    if (!csvPath) {
+      res.status(400).json({ error: "Unable to determine uploaded file path" });
+      return;
+    }
+
+    const bundleDir = path.join(process.cwd(), "exo_bundle_v4");
+    const result = await runPythonVisualize(bundleDir, csvPath);
+
+    if (result.error) {
+      res.status(500).json({ error: result.error });
+      return;
+    }
+
+    res.status(200).json(result);
+  } catch (err) {
+    console.error("Visualize upload error", err);
+    res.status(500).json({ error: (err as Error).message });
+  }
+}

--- a/src/styles/pages/visualize.module.css
+++ b/src/styles/pages/visualize.module.css
@@ -40,6 +40,33 @@
   opacity: 0.7;
 }
 
+.uploadForm {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.uploadForm button {
+  padding: 8px 18px;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(90deg, #7f8cff, #df6ac9);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.uploadForm button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.error {
+  color: #ff7b7b;
+  margin: 6px 0 0;
+}
+
 .grid {
   display: grid;
   gap: 20px;
@@ -213,6 +240,13 @@
 .metricValue {
   font-size: 22px;
   font-weight: 600;
+}
+
+.duplicateCard {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-size: 13px;
 }
 
 .chartCanvas {


### PR DESCRIPTION
## Summary
- add a visualization payload builder to `exo_infer.py`, including training reference drift stats and CLI `--mode visualize`
- expose `/api/visualize` upload endpoint that pipes validated CSVs to the Python visualizer
- replace the visualize page placeholder with upload-driven state handling, chart rendering, and refreshed styles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e254c5b87483328f79571b70ecbbfc